### PR TITLE
Added endpoints to display arriving data within the dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - KAFKA_HOST=kafka
       - KAFKA_PORT=${KAFKA_PORT}
       - KAFKA_TOPIC=network.data.ingested
+      - CORS_ORIGINS=http://localhost:5173,http://localhost:3000,http://127.0.0.1:5173
     networks:
       - nwdaf-network
 

--- a/receiver.py
+++ b/receiver.py
@@ -33,13 +33,12 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # CORS middleware
+origins = os.getenv("CORS_ORIGINS", "")
+allowed_origins = [o.strip() for o in origins.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",  # Vite dev server
-        "http://localhost:3000",  # Alternative React dev port
-        "http://127.0.0.1:5173",
-    ],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],  # Allows GET, POST, etc.
     allow_headers=["*"],  # Allows all headers


### PR DESCRIPTION
* Added a deque-based `data_store` to keep the last 1000 received data entries in memory. 
* Updated the data receiving endpoint to append each processed data packet to `data_store`. 
* Added new API endpoints: `/data` to return all stored entries, and `/data/latest/{count}` to return the latest N entries. 
* Introduced CORS middleware to allow requests from local frontend development servers (Vite/React), supporting cross-origin requests.