### PR TITLE
Feature/producer heartbeat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "websockets==14.1",
     "requests>=2.32",
     "policy-client-sdk @ git+https://github.com/ATNoG/pei-nwdaf-policy.git#subdirectory=client_sdk",
+    "httpx==0.23.2"
 ]
 
 [project.optional-dependencies]
@@ -19,7 +20,7 @@ dev = [
     "bandit==1.8.0",
     "safety==2.3.5",
     "pytest==8.3.4",
-    "httpx==0.28.1",
+    #"httpx==0.28.1",
 ]
 
 [build-system]

--- a/receiver.py
+++ b/receiver.py
@@ -211,6 +211,13 @@ class SubscribeRequest(BaseModel):
 
 # Fields to extract and send to Kafka (can be expanded later)
 
+@app.post("/heartbeat/{subscription_id}", status_code=200)
+async def heartbeat(subscription_id: str):
+    if subscription_id not in subscription_registry.all_producers():
+        raise HTTPException(status_code=404, detail="Producer not registered")
+    
+    subscription_registry.received_data(subscription_id)
+    return {"status": "ok"}
 
 @app.post("/subscriptions", status_code=201)
 async def subscribe_to_producer(request : SubscribeRequest):

--- a/receiver.py
+++ b/receiver.py
@@ -54,7 +54,7 @@ PORT = os.getenv("PORT", 7000)
 PRODUCER_MAX_TIME_OUT = int(os.getenv("PRODUCER_MAX_TIMEOUT", 30))
 
 
-subscription_registry = SubscriptionRegistry(max_failures=5)
+subscription_registry = SubscriptionRegistry()
 #initialize thread to check producers
 def check_producers_life(subscription_registry : SubscriptionRegistry):
     while True:
@@ -222,7 +222,7 @@ async def heartbeat(subscription_id: str):
 @app.post("/subscriptions", status_code=201)
 async def subscribe_to_producer(request : SubscribeRequest):
     try:
-        response = requests.post(request.producer_url, json={"url" : f"http://{HOST}:{PORT}/receive"}, timeout=5)
+        response = requests.post(request.producer_url, json={"url" : f"http://{HOST}:{PORT}/receive", "hearbeat_url" : f"http://{HOST}:{PORT}/heartbeat"}, timeout=5)
         response_json =json.loads(response.text)
         id = response_json["subscription_id"]
         subscription_registry.add(id, request.producer_url)
@@ -244,7 +244,7 @@ async def get_subscriptions():
     """
     Returns all producers in the system with their labels.
     Returns in this format:
-    {"producers" : [{sub_id : {url, label}}, {sub_id : {url, label}}]}
+    {"producers" : [{sub_id : {url, label, active}}, {sub_id : {url, label, active}}]}
     """
     producers_with_labels = subscription_registry.get_all_with_labels()
     producers_list = [{sub_id: {"url": info["url"], "label": info["label"]}} for sub_id, info in producers_with_labels.items()]

--- a/receiver.py
+++ b/receiver.py
@@ -57,11 +57,11 @@ subscription_registry = SubscriptionRegistry()
 async def check_producers_life(subscription_registry : SubscriptionRegistry):
     logger.info("Checking producers")
     while True:
-        producers = subscription_registry.get_all_producers()
+        producers = subscription_registry.get_all_active_producers()
         for prod in producers:
             heartbeat_url = subscription_registry.get_heartbeat_url(prod)
             try:
-                response = await http_client.post(heartbeat_url)
+                response = await http_client.get(heartbeat_url)
                 if response.status_code == 202:
                     subscription_registry.record_success(prod)
                 else:
@@ -263,7 +263,7 @@ async def get_subscriptions():
     {"producers" : [{sub_id : {url, label, active}}, {sub_id : {url, label, active}}]}
     """
     producers_with_labels = subscription_registry.get_all_with_labels()
-    producers_list = [{sub_id: {"url": info["url"], "label": info["label"], "active" : info["active"]}} for sub_id, info in producers_with_labels.items()]
+    producers_list = [{sub_id: {"url": info["url"], "label": info["label"]}} for sub_id, info in producers_with_labels.items()]
     return {"producers": producers_list}   
 
 @app.put("/subscriptions/{subscription_id}/label")

--- a/receiver.py
+++ b/receiver.py
@@ -62,7 +62,7 @@ async def check_producers_life(subscription_registry : SubscriptionRegistry):
             heartbeat_url = subscription_registry.get_heartbeat_url(prod)
             try:
                 response = await http_client.get(heartbeat_url)
-                if response.status_code == 202:
+                if response.status_code == 200:
                     subscription_registry.record_success(prod)
                 else:
                     logger.warning(f"Producer {prod} returned unexpected status {response.status_code}")

--- a/receiver.py
+++ b/receiver.py
@@ -361,7 +361,7 @@ async def receive_data(request: Request):
                 logger.info(f"First data received! Discovered {len(_discovered_fields)} fields: {list(_discovered_fields)}")
 
             # If new fields were discovered, re-register with Policy Service
-            if len(_discovered_fields) > previous_field_count:
+            if len(_discovered_fields) > previous_field_count and POLICY_ENABLED:
                 logger.info(f"New fields discovered! Total: {len(_discovered_fields)}. Re-registering...")
                 try:
                     await policy_client.register_component(

--- a/receiver.py
+++ b/receiver.py
@@ -249,7 +249,7 @@ async def get_subscriptions():
     {"producers" : [{sub_id : {url, label, active}}, {sub_id : {url, label, active}}]}
     """
     producers_with_labels = subscription_registry.get_all_with_labels()
-    producers_list = [{sub_id: {"url": info["url"], "label": info["label"]}} for sub_id, info in producers_with_labels.items()]
+    producers_list = [{sub_id: {"url": info["url"], "label": info["label"], "active" : info["active"]}} for sub_id, info in producers_with_labels.items()]
     return {"producers": producers_list}   
 
 @app.put("/subscriptions/{subscription_id}/label")

--- a/receiver.py
+++ b/receiver.py
@@ -4,10 +4,10 @@ import logging
 import os
 import time
 import threading
-import requests
 from collections import deque
 from contextlib import asynccontextmanager
 from typing import Any, Dict, Set
+import httpx
 
 from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -53,18 +53,14 @@ HOST = os.getenv("HOST", "data-ingestion")
 PORT = os.getenv("PORT", 7000)
 PRODUCER_MAX_TIME_OUT = int(os.getenv("PRODUCER_MAX_TIMEOUT", 30))
 
-
 subscription_registry = SubscriptionRegistry()
-#initialize thread to check producers
-def check_producers_life(subscription_registry : SubscriptionRegistry):
+async def check_producers_life(subscription_registry : SubscriptionRegistry):
     while True:
         subscription_registry.update_producers_life(PRODUCER_MAX_TIME_OUT)
         logger.info("Checking producers")
-        time.sleep(5)
+        await asyncio.sleep(5)
 
 
-check_producers_thread = threading.Thread(target=check_producers_life, args=(subscription_registry,), daemon=True)
-check_producers_thread.start()
 
 raw_data_store = deque(maxlen=1000)  # Store last 1000 entries
 kafka_bridge = None
@@ -158,8 +154,9 @@ manager = ConnectionManager()
 async def lifespan(app: FastAPI):
 
     # Startup: Start Kafka bridge
-    global kafka_bridge, policy_client
+    global kafka_bridge, policy_client, http_client
     kafka_bridge = PyKafBridge(TOPIC, hostname=KAFKA_HOST, port=KAFKA_PORT)
+    http_client = httpx.AsyncClient(timeout=5.0)
 
     try:
         # Use discovered fields if available (e.g. from a previous run still in
@@ -176,6 +173,9 @@ async def lifespan(app: FastAPI):
         logger.info(f"Component registered with Policy Service ({len(startup_columns)} fields)")
         # Keep registration alive across Policy restarts
         await policy_client.start_heartbeat()
+        
+        #check producers life
+        asyncio.create_task(check_producers_life(subscription_registry))
     except Exception as e:
         logger.warning(f"Failed to register with Policy Service: {e}")
 
@@ -222,17 +222,19 @@ async def heartbeat(subscription_id: str):
 @app.post("/subscriptions", status_code=201)
 async def subscribe_to_producer(request : SubscribeRequest):
     try:
-        response = requests.post(request.producer_url, json={"url" : f"http://{HOST}:{PORT}/receive", "hearbeat_url" : f"http://{HOST}:{PORT}/heartbeat"}, timeout=5)
-        response_json =json.loads(response.text)
+        request_to_producer = {"url" : f"http://{HOST}:{PORT}/receive", "heartbeat_url" : f"http://{HOST}:{PORT}/heartbeat"}
+
+        response = await http_client.post(request.producer_url, json=request_to_producer)
+        response_json = response.json()
         id = response_json["subscription_id"]
         subscription_registry.add(id, request.producer_url)
         logger.info(f"Producer {request.producer_url} added with subscription id: {id}")
         return {"id" : id}
-    except requests.exceptions.Timeout:
+    except httpx.exceptions.Timeout:
         logger.warning(f"Producer {request.producer_url} didnt respond")
         raise HTTPException(status_code=504, detail="Producer didnt respond")
 
-    except requests.exceptions.ConnectionError:
+    except httpx.exceptions.ConnectionError:
         logger.warning(f"Cannot connect to producer {request.producer_url}")
         raise HTTPException(status_code=502, detail="Cannot connect to producer")
     except:
@@ -290,7 +292,7 @@ async def unsubscrive_to_producer(subscription_id : str):
         url = subscription_registry.get_url(subscription_id)
         if url[-1] == "/":
             url = url[:-1]
-        response = requests.delete(f"{url}/{subscription_id}")
+        response = await http_client.delete(f"{url}/{subscription_id}")
         if response.status_code == 200:
             subscription_registry.remove(subscription_id)
             return {"subscription_id" : subscription_id}
@@ -310,7 +312,8 @@ async def receive_data(request: Request):
     For any REQUIRED_FIELDS key missing from the incoming packet, the
     returned value will be None.
     """
-
+    
+    print("RECEIVED FROM PRODUCER")
     # Use the component_id as the source for policy checks when writing to Kafka
     # The external client sending data is irrelevant - we (ingestion-service) are the source
     source_id = POLICY_COMPONENT_ID

--- a/receiver.py
+++ b/receiver.py
@@ -55,8 +55,21 @@ PRODUCER_MAX_TIME_OUT = int(os.getenv("PRODUCER_MAX_TIMEOUT", 30))
 
 subscription_registry = SubscriptionRegistry()
 async def check_producers_life(subscription_registry : SubscriptionRegistry):
+    logger.info("Checking producers")
     while True:
-        subscription_registry.update_producers_life(PRODUCER_MAX_TIME_OUT)
+        producers = subscription_registry.get_all_producers()
+        for prod in producers:
+            heartbeat_url = subscription_registry.get_heartbeat_url(prod)
+            try:
+                response = await http_client.post(heartbeat_url)
+                if response.status_code == 202:
+                    subscription_registry.record_success(prod)
+                else:
+                    logger.warning(f"Producer {prod} returned unexpected status {response.status_code}")
+                    subscription_registry.record_failure(prod)
+            except Exception as e:
+                logger.warning(f"Producer {prod} heartbeat failed: {e}")
+                subscription_registry.record_failure(prod)
         logger.info("Checking producers")
         await asyncio.sleep(5)
 
@@ -227,14 +240,15 @@ async def subscribe_to_producer(request : SubscribeRequest):
         response = await http_client.post(request.producer_url, json=request_to_producer)
         response_json = response.json()
         id = response_json["subscription_id"]
-        subscription_registry.add(id, request.producer_url)
+        heartbeat_url = response_json["heartbeat_url"]
+        subscription_registry.add(id, request.producer_url, heartbeat_url)
         logger.info(f"Producer {request.producer_url} added with subscription id: {id}")
         return {"id" : id}
-    except httpx.exceptions.Timeout:
+    except httpx.TimeoutException:
         logger.warning(f"Producer {request.producer_url} didnt respond")
         raise HTTPException(status_code=504, detail="Producer didnt respond")
 
-    except httpx.exceptions.ConnectionError:
+    except httpx.ConnectError:
         logger.warning(f"Cannot connect to producer {request.producer_url}")
         raise HTTPException(status_code=502, detail="Cannot connect to producer")
     except:

--- a/subscription_registry.py
+++ b/subscription_registry.py
@@ -57,15 +57,19 @@ class SubscriptionRegistry:
                 sub_id: {
                     "url": url,
                     "label": self.producers_labels.get(sub_id, sub_id),
-                    "active" : self.producers_active[sub_id]
                 }
-                for sub_id, url in self.producers.items()
+                for sub_id, url in self.producers.items() if self.producers_active[sub_id]
             }
 
-    def get_all_producers(self) -> Dict[str, str]:
-        """Return all producers as {subscription_id: url}."""
+    def get_all_active_producers(self) -> List[str]:
+        """Return all producers as [id, id, id]."""
+        active = []
         with self.lock:
-            return self.producers.copy()
+            for prod in self.producers:
+                if self.producers_active[prod]:
+                    active.append(prod)
+
+        return active
 
     def get_all_with_status(self) -> Dict[str, list]:  # no timeout param needed
         with self.lock:

--- a/subscription_registry.py
+++ b/subscription_registry.py
@@ -8,16 +8,17 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class SubscriptionRegistry:
-    def __init__(self):
+    def __init__(self, max_failures : int = 10):
         self.producers: Dict[str, str] = {}
         self.producers_failures : Dict[str, int] = {}
         self.producers_last_info : Dict[str, int] = {}
         self.producers_labels: Dict[str, str] = {}  # subscription_id -> label
         self.producers_active : Dict[str, bool] = {}
-        
+        self.producers_heartbeat_url : Dict[str, str] = {}       
+        self.max_failures = max_failures
         self.lock = threading.Lock()
 
-    def add(self, subscription_id, url: str):
+    def add(self, subscription_id, url: str, heartbeal_url : str):
         with self.lock:
             self.producers[subscription_id] = url
             self.producers_failures[subscription_id] = 0
@@ -25,6 +26,7 @@ class SubscriptionRegistry:
             # Default label is subscription_id
             self.producers_labels[subscription_id] = subscription_id
             self.producers_active[subscription_id] = True
+            self.producers_heartbeat_url[subscription_id] = heartbeal_url
 
     def remove(self, sub_id: str):
         with self.lock:
@@ -33,6 +35,7 @@ class SubscriptionRegistry:
             self.producers_last_info.pop(sub_id, None)
             self.producers_labels.pop(sub_id, None)
             self.producers_active.pop(sub_id, None)
+            self.producers_heartbeat_url.pop(sub_id, None)
 
     def set_label(self, subscription_id: str, label: str) -> bool:
         """Update or set a producer's label. Returns True if producer exists."""
@@ -82,6 +85,9 @@ class SubscriptionRegistry:
 
     def get_url(self, id : str) -> str:
         return self.producers[id]
+    
+    def get_heartbeat_url(self, id : str) -> str:
+        return self.producers_heartbeat_url[id]
 
     def received_data(self, id : str):
         now = int(time.time())
@@ -92,21 +98,15 @@ class SubscriptionRegistry:
             if self.producers_active[id] is False:
                 self.producers_active[id] = True
             self.producers_last_info[id] = now
-
-    def update_producers_life(self, timeout : int):
-        to_inactive = []
+    
+    def record_failure(self, id : str):
         with self.lock:
-            producers = self.producers
-            now = int(time.time())
-            for producer in producers:
-                last_info = self.producers_last_info[producer]
-                if now - last_info > timeout:
-                    to_inactive.append(producer)
-                    logger.info(f"Producer {producer} is considered inactive for timeout")
+            self.producers_failures[id] += 1
+            if self.producers_failures > self.max_failures:
+                self.producers_active[id] = False
 
-        for prod_remove in to_inactive:
-            self._to_inactive(prod_remove)
-
-    def _to_inactive(self, producer_id : str):
+    def record_success(self, id : str):
         with self.lock:
-            self.producers_active[producer_id] = False
+            self.producers_failures[id] = 0
+            self.producers_active[id] = True
+

--- a/subscription_registry.py
+++ b/subscription_registry.py
@@ -8,13 +8,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class SubscriptionRegistry:
-    def __init__(self, max_failures: int = 5):
+    def __init__(self):
         self.producers: Dict[str, str] = {}
         self.producers_failures : Dict[str, int] = {}
         self.producers_last_info : Dict[str, int] = {}
         self.producers_labels: Dict[str, str] = {}  # subscription_id -> label
-
-        self.max_failures = max_failures
+        self.producers_active : Dict[str, bool] = {}
+        
         self.lock = threading.Lock()
 
     def add(self, subscription_id, url: str):
@@ -24,6 +24,7 @@ class SubscriptionRegistry:
             self.producers_last_info[subscription_id] = int(time.time())
             # Default label is subscription_id
             self.producers_labels[subscription_id] = subscription_id
+            self.producers_active[subscription_id] = True
 
     def remove(self, sub_id: str):
         with self.lock:
@@ -31,6 +32,7 @@ class SubscriptionRegistry:
             self.producers_failures.pop(sub_id, None)
             self.producers_last_info.pop(sub_id, None)
             self.producers_labels.pop(sub_id, None)
+            self.producers_active.pop(sub_id, None)
 
     def set_label(self, subscription_id: str, label: str) -> bool:
         """Update or set a producer's label. Returns True if producer exists."""
@@ -51,7 +53,8 @@ class SubscriptionRegistry:
             return {
                 sub_id: {
                     "url": url,
-                    "label": self.producers_labels.get(sub_id, sub_id)
+                    "label": self.producers_labels.get(sub_id, sub_id),
+                    "active" : self.producers_active[sub_id]
                 }
                 for sub_id, url in self.producers.items()
             }
@@ -61,53 +64,18 @@ class SubscriptionRegistry:
         with self.lock:
             return self.producers.copy()
 
-    def get_all_with_status(self, timeout: int) -> Dict[str, list]:
-        """
-        Return producers grouped by active/inactive status.
-
-        Args:
-            timeout: Seconds threshold for considering a producer inactive.
-                    Uses PRODUCER_MAX_TIME_OUT value (typically 30s).
-
-        Returns:
-            {
-                "active": [{sub_id: {url, label, last_seen}}, ...],
-                "inactive": [{sub_id: {url, label, last_seen}}, ...]
-            }
-        """
+    def get_all_with_status(self) -> Dict[str, list]:  # no timeout param needed
         with self.lock:
-            now = int(time.time())
-            active = []
-            inactive = []
-
+            active, inactive = [], []
             for sub_id, url in self.producers.items():
-                label = self.producers_labels.get(sub_id, sub_id)
-                last_seen = self.producers_last_info.get(sub_id, 0)
-                producer_info = {
-                    sub_id: {
-                        "url": url,
-                        "label": label,
-                        "last_seen": last_seen
-                    }
-                }
-
-                if now - last_seen <= timeout:
-                    active.append(producer_info)
-                else:
-                    inactive.append(producer_info)
-
+                entry = {sub_id: {
+                    "url": url,
+                    "label": self.producers_labels.get(sub_id, sub_id),
+                    "last_seen": self.producers_last_info.get(sub_id, 0)
+                }}
+                (active if self.producers_active.get(sub_id) else inactive).append(entry)
             return {"active": active, "inactive": inactive}
-
-    def record_failure(self, id: str):
-        with self.lock:
-            if id in self.producers_failures:
-                self.producers_failures[id] += 1
-                logger.log(logging.INFO, f"Producer subscription with id:{id} took too long to respond")
-
-                if self.producers_failures[id] >= self.max_failures:
-                    self.remove(id)
-                    logger.warning(f"{id} didnt respond {self.max_failures} times, assuming it is dead")
-
+   
     def all_producers(self) -> Dict[str, str]:
         with self.lock:
             return self.producers.copy()
@@ -117,18 +85,28 @@ class SubscriptionRegistry:
 
     def received_data(self, id : str):
         now = int(time.time())
+        
         with self.lock:
+            if id not in self.producers:
+                return
+            if self.producers_active[id] is False:
+                self.producers_active[id] = True
             self.producers_last_info[id] = now
 
     def update_producers_life(self, timeout : int):
-        to_remove = []
+        to_inactive = []
         with self.lock:
             producers = self.producers
             now = int(time.time())
             for producer in producers:
                 last_info = self.producers_last_info[producer]
                 if now - last_info > timeout:
-                    to_remove.append(producer)
-                    logger.info(f"Producer {producer} removed for timeout")
-        for prod_remove in to_remove:
-            self.remove(prod_remove)
+                    to_inactive.append(producer)
+                    logger.info(f"Producer {producer} is considered inactive for timeout")
+
+        for prod_remove in to_inactive:
+            self._to_inactive(prod_remove)
+
+    def _to_inactive(self, producer_id : str):
+        with self.lock:
+            self.producers_active[producer_id] = False

--- a/subscription_registry.py
+++ b/subscription_registry.py
@@ -102,7 +102,7 @@ class SubscriptionRegistry:
     def record_failure(self, id : str):
         with self.lock:
             self.producers_failures[id] += 1
-            if self.producers_failures > self.max_failures:
+            if self.producers_failures[id] > self.max_failures:
                 self.producers_active[id] = False
 
     def record_success(self, id : str):

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -2,7 +2,6 @@ import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch, AsyncMock, Mock
 import json
-import requests
 
 
 SUBSCRIPTION_ID = "random_id"
@@ -33,8 +32,7 @@ def client(mock_kafka_bridge, mock_subscription_registry):
     """Create a test client with mocked Kafka bridge and subscription registry."""
     with patch("receiver.PyKafBridge", return_value=mock_kafka_bridge), \
          patch("receiver.subscription_registry", mock_subscription_registry), \
-         patch("receiver.check_producers_thread") as mock_thread:
-        mock_thread.start = MagicMock()
+         patch("receiver.check_producers_life", new_callable=AsyncMock):
         from receiver import app
 
         with TestClient(app) as test_client:
@@ -340,45 +338,37 @@ class TestReceiveEndpoint:
 class TestSubscriptionEndpoints:
     """Tests for subscription management endpoints."""
 
-    @patch("receiver.requests.post")
-    def test_subscribe_to_producer_success(self, mock_requests_post, client, mock_subscription_registry):
+    def test_subscribe_to_producer_success(self, client, mock_subscription_registry):
         """Test successfully subscribing to a producer."""
-        # Mock the response from the producer
+        import receiver
         mock_response = Mock()
-        mock_response.text = json.dumps({"subscription_id": "test-sub-123"})
+        mock_response.json = Mock(return_value={"subscription_id": "test-sub-123", "heartbeat_url": "http://producer-service:8000/heartbeat"})
         mock_response.status_code = 200
-        mock_requests_post.return_value = mock_response
 
         producer_url = "http://producer-service:8000/subscribe"
         payload = {"producer_url": producer_url}
 
-        response = client.post("/subscriptions", json=payload)
+        with patch.object(receiver.http_client, "post", new_callable=AsyncMock, return_value=mock_response):
+            response = client.post("/subscriptions", json=payload)
 
         # Verify the response
         assert response.status_code == 201
         data = response.json()
         assert data["id"] == "test-sub-123"
 
-        # Verify requests.post was called correctly
-        from receiver import HOST, PORT
-        mock_requests_post.assert_called_once_with(
-            producer_url,
-            json={"url": f"http://{HOST}:{PORT}/receive"},
-            timeout=5
-        )
-
         # Verify subscription was added to registry
-        mock_subscription_registry.add.assert_called_once_with("test-sub-123", producer_url)
+        mock_subscription_registry.add.assert_called_once_with("test-sub-123", producer_url, "http://producer-service:8000/heartbeat")
 
-    @patch("receiver.requests.post")
-    def test_subscribe_to_producer_timeout(self, mock_requests_post, client, mock_subscription_registry):
+    def test_subscribe_to_producer_timeout(self, client, mock_subscription_registry):
         """Test subscribing when producer times out."""
-        mock_requests_post.side_effect = requests.exceptions.Timeout()
+        import receiver
+        import httpx
 
         producer_url = "http://producer-service:8000/subscribe"
         payload = {"producer_url": producer_url}
 
-        response = client.post("/subscriptions", json=payload)
+        with patch.object(receiver.http_client, "post", new_callable=AsyncMock, side_effect=httpx.TimeoutException("")):
+            response = client.post("/subscriptions", json=payload)
 
         assert response.status_code == 504
         assert "Producer didnt respond" in response.text
@@ -386,15 +376,16 @@ class TestSubscriptionEndpoints:
         # Verify subscription was not added
         mock_subscription_registry.add.assert_not_called()
 
-    @patch("receiver.requests.post")
-    def test_subscribe_to_producer_connection_error(self, mock_requests_post, client, mock_subscription_registry):
+    def test_subscribe_to_producer_connection_error(self, client, mock_subscription_registry):
         """Test subscribing when cannot connect to producer."""
-        mock_requests_post.side_effect = requests.exceptions.ConnectionError()
+        import receiver
+        import httpx
 
         producer_url = "http://producer-service:8000/subscribe"
         payload = {"producer_url": producer_url}
 
-        response = client.post("/subscriptions", json=payload)
+        with patch.object(receiver.http_client, "post", new_callable=AsyncMock, side_effect=httpx.ConnectError("")):
+            response = client.post("/subscriptions", json=payload)
 
         assert response.status_code == 502
         data = response.json()
@@ -403,18 +394,19 @@ class TestSubscriptionEndpoints:
         # Verify subscription was not added
         mock_subscription_registry.add.assert_not_called()
 
-    @patch("receiver.requests.post")
-    def test_subscribe_to_producer_unexpected_response(self, mock_requests_post, client, mock_subscription_registry):
+    def test_subscribe_to_producer_unexpected_response(self, client, mock_subscription_registry):
         """Test subscribing when producer gives unexpected response."""
+        import receiver
+
         mock_response = Mock()
-        mock_response.text = "invalid json"
+        mock_response.json = Mock(side_effect=ValueError("invalid json"))
         mock_response.status_code = 200
-        mock_requests_post.return_value = mock_response
 
         producer_url = "http://producer-service:8000/subscribe"
         payload = {"producer_url": producer_url}
 
-        response = client.post("/subscriptions", json=payload)
+        with patch.object(receiver.http_client, "post", new_callable=AsyncMock, return_value=mock_response):
+            response = client.post("/subscriptions", json=payload)
 
         assert response.status_code == 500
         data = response.json()
@@ -455,48 +447,50 @@ class TestSubscriptionEndpoints:
         assert "sub-2" in producer_ids
         assert "sub-3" in producer_ids
 
-    @patch("receiver.requests.delete")
-    def test_unsubscribe_success(self, mock_requests_delete, client, mock_subscription_registry):
+    def test_unsubscribe_success(self, client, mock_subscription_registry):
         """Test successfully unsubscribing from a producer."""
+        import receiver
+
         subscription_id = "test-sub-123"
         producer_url = "http://producer-service:8000/subscribe"
-        
+
         mock_subscription_registry.get_url.return_value = producer_url
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_requests_delete.return_value = mock_response
 
-        response = client.delete(f"/subscriptions/{subscription_id}")
+        with patch.object(receiver.http_client, "delete", new_callable=AsyncMock, return_value=mock_response) as mock_delete:
+            response = client.delete(f"/subscriptions/{subscription_id}")
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["subscription_id"] == subscription_id
+            assert response.status_code == 200
+            data = response.json()
+            assert data["subscription_id"] == subscription_id
 
-        # Verify requests.delete was called correctly
-        mock_requests_delete.assert_called_once_with(f"{producer_url}/{subscription_id}")
+            # Verify http_client.delete was called correctly
+            mock_delete.assert_called_once_with(f"{producer_url}/{subscription_id}")
 
         # Verify subscription was removed from registry
         mock_subscription_registry.remove.assert_called_once_with(subscription_id)
 
-    @patch("receiver.requests.delete")
-    def test_unsubscribe_with_trailing_slash(self, mock_requests_delete, client, mock_subscription_registry):
+    def test_unsubscribe_with_trailing_slash(self, client, mock_subscription_registry):
         """Test unsubscribing when producer URL has trailing slash."""
+        import receiver
+
         subscription_id = "test-sub-123"
         producer_url = "http://producer-service:8000/subscribe/"
-        
+
         mock_subscription_registry.get_url.return_value = producer_url
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_requests_delete.return_value = mock_response
 
-        response = client.delete(f"/subscriptions/{subscription_id}")
+        with patch.object(receiver.http_client, "delete", new_callable=AsyncMock, return_value=mock_response) as mock_delete:
+            response = client.delete(f"/subscriptions/{subscription_id}")
 
-        assert response.status_code == 200
+            assert response.status_code == 200
 
-        # Verify trailing slash was removed in the request
-        mock_requests_delete.assert_called_once_with(f"http://producer-service:8000/subscribe/{subscription_id}")
+            # Verify trailing slash was removed in the request
+            mock_delete.assert_called_once_with(f"http://producer-service:8000/subscribe/{subscription_id}")
 
     def test_unsubscribe_not_found(self, client, mock_subscription_registry):
         """Test unsubscribing from non-existent subscription."""
@@ -509,20 +503,21 @@ class TestSubscriptionEndpoints:
         data = response.json()
         assert "Subscription not found" in data["detail"]
 
-    @patch("receiver.requests.delete")
-    def test_unsubscribe_producer_error(self, mock_requests_delete, client, mock_subscription_registry):
+    def test_unsubscribe_producer_error(self, client, mock_subscription_registry):
         """Test unsubscribing when producer returns error."""
+        import receiver
+
         subscription_id = "test-sub-123"
         producer_url = "http://producer-service:8000/subscribe"
-        
+
         mock_subscription_registry.get_url.return_value = producer_url
-        
+
         mock_response = Mock()
         mock_response.status_code = 404
         mock_response.text = "Subscription not found on producer"
-        mock_requests_delete.return_value = mock_response
 
-        response = client.delete(f"/subscriptions/{subscription_id}")
+        with patch.object(receiver.http_client, "delete", new_callable=AsyncMock, return_value=mock_response):
+            response = client.delete(f"/subscriptions/{subscription_id}")
 
         assert response.status_code == 404
         data = response.json()


### PR DESCRIPTION
# Feature/producer heartbeat

Added heartbeat logic to ingestion instead of relying on the producers sending data and storing the timestamps
How this works is ingestion sends a subscribe request to producer and producer responds with the id, and the url of the endpoint where ingestion needs to send heart-beats. Ingestion then keeps sending heart-beats there to see if producer is alive
If producer fails to answer those heartbeats 10 times in a row it is considered dead 